### PR TITLE
Changes to support gcc 6.4.0

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -20,7 +20,7 @@ cmake_minimum_required(VERSION 3.13)
 
 project(dsm_core)
 
-set(CMAKE_CXX_STANDARD 17)
+set(CMAKE_CXX_STANDARD 11)
 set(CMAKE_BINARY_DIR "${CMAKE_SOURCE_DIR}/build")
 set(CMAKE_SOURCE_DIR "${CMAKE_SOURCE_DIR}/src")
 message("[./] CMAKE_SOURCE_DIR ${CMAKE_SOURCE_DIR}")

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -53,8 +53,8 @@ if (ENABLE_RBUS_PROVIDER)
     set(RBUS_SRC
                 "${CMAKE_SOURCE_DIR}/rbus/dsm_rbus_provider.cpp"
                 )
- 
-    include_directories(SYSTEM  /usr/include/rbus ${CMAKE_SOURCE_DIR})
+    include(GNUInstallDirs)
+    include_directories(SYSTEM  ${OE_SYSROOT}/${CMAKE_INSTALL_OLDINCLUDEDIR}/rbus ${CMAKE_SOURCE_DIR})
     add_definitions(-DENABLE_RBUS_PROVIDER)
 endif(ENABLE_RBUS_PROVIDER)
 

--- a/src/librbusprovider/CMakeLists.txt
+++ b/src/librbusprovider/CMakeLists.txt
@@ -31,10 +31,16 @@ if (ENABLE_STATIC_ANALYSIS)
     set(CMAKE_CXX_CLANG_TIDY clang-tidy -checks=*,clang-analyzer-*,-readability-*,-fuchsia-*,-google-*,-modernize-use-trailing-return-type,-llvm-include-order)
     set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -g -Wall -Wextra -pthread ")
 else()
-    set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -g -Wall -Wextra -Werror -Wshadow -Wnon-virtual-dtor -Wconversion -Wduplicated-cond -Wduplicated-branches  -Wlogical-op -Wnull-dereference -Wuseless-cast -Wformat=2 -pthread ") 
+    set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -g -Wall -Wextra -Werror -Wshadow -Wformat=2 -pthread ") 
+    if("${CMAKE_CXX_COMPILER_ID}" STREQUAL "GNU")
+        # require at least gcc 7.4 for these checks
+        if (NOT CMAKE_CXX_COMPILER_VERSION VERSION_LESS 7.4)
+            set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wnon-virtual-dtor -Wconversion -Wduplicated-cond -Wduplicated-branches  -Wlogical-op -Wnull-dereference -Wuseless-cast ") 
+        endif()
+    endif()
 endif(ENABLE_STATIC_ANALYSIS)
 
-set (CMAKE_CXX_STANDARD 17)
+set (CMAKE_CXX_STANDARD 11)
 
 FILE(GLOB SRC "./*.cpp")
 FILE(GLOB HEADERS "./*.h")

--- a/src/librbusprovider/CMakeLists.txt
+++ b/src/librbusprovider/CMakeLists.txt
@@ -52,7 +52,7 @@ set_target_properties(  rbusprovider PROPERTIES PREFIX ""
                         rbusprovider PROPERTIES PUBLIC_HEADER "${HEADERS}"
                      )
          
-include_directories(SYSTEM  /usr/include/rbus)
+include_directories(SYSTEM  ${OE_SYSROOT}/${CMAKE_INSTALL_OLDINCLUDEDIR}/rbus)
 target_link_libraries(rbusprovider rbus)
 
 INSTALL(TARGETS rbusprovider

--- a/src/librbusprovider/provider.cpp
+++ b/src/librbusprovider/provider.cpp
@@ -201,7 +201,7 @@ rbusError_t rbus_provider::setData(rbus_data& data,rbusProperty_t property)
     return (rbusError_t::RBUS_ERROR_SUCCESS);
 }
 
-rbusError_t rbus_provider::setHandler ([[maybe_unused]] rbusHandle_t handle, [[maybe_unused]] rbusProperty_t property, [[maybe_unused]] rbusSetHandlerOptions_t* options) {
+rbusError_t rbus_provider::setHandler (UNUSED_CHECK rbusHandle_t handle, UNUSED_CHECK rbusProperty_t property, UNUSED_CHECK rbusSetHandlerOptions_t* options) {
     
     char const* const name = rbusProperty_GetName(property); 
     if (name != nullptr) {
@@ -213,7 +213,7 @@ rbusError_t rbus_provider::setHandler ([[maybe_unused]] rbusHandle_t handle, [[m
     return rbusError_t::RBUS_ERROR_BUS_ERROR;
 }
 
-rbusError_t rbus_provider::getHandler ([[maybe_unused]] rbusHandle_t handle, rbusProperty_t property, [[maybe_unused]] rbusGetHandlerOptions_t* options) { 
+rbusError_t rbus_provider::getHandler (UNUSED_CHECK rbusHandle_t handle, rbusProperty_t property, UNUSED_CHECK rbusGetHandlerOptions_t* options) { 
     char const* const name = rbusProperty_GetName(property); 
     if (name != nullptr) {
         auto const it = rbus_provider::elements.find(name);
@@ -251,7 +251,7 @@ void rbus_provider::registerTables()
     }
 }
 
-rbusError_t rbus_provider::eventSubHandler([[maybe_unused]] rbusHandle_t handle, rbusEventSubAction_t action, const char* eventName,[[maybe_unused]]  rbusFilter_t filter,[[maybe_unused]]  int32_t interval,[[maybe_unused]]  bool* autoPublish)
+rbusError_t rbus_provider::eventSubHandler(UNUSED_CHECK rbusHandle_t handle, rbusEventSubAction_t action, const char* eventName,UNUSED_CHECK  rbusFilter_t filter,UNUSED_CHECK  int32_t interval,UNUSED_CHECK  bool* autoPublish)
 {
     std::cout << (action == RBUS_EVENT_ACTION_SUBSCRIBE ? "subscribe" : "unsubscribe") << " for "<< eventName << std::endl;
     return RBUS_ERROR_SUCCESS;

--- a/src/librbusprovider/provider.h
+++ b/src/librbusprovider/provider.h
@@ -22,6 +22,7 @@
 #include <map>
 #include <cstdint>
 #include <thread>
+#include "rbus_macros.h"
 #include "table.h"
 
 struct rbus_data {
@@ -57,10 +58,10 @@ public:
 
     static std::map<std::string,rbus_table> tables;
 
-    [[nodiscard]] static rbusError_t getHandler (rbusHandle_t handle, rbusProperty_t property, rbusGetHandlerOptions_t* options);
-    [[nodiscard]] static rbusError_t setHandler (rbusHandle_t handle, rbusProperty_t property, rbusSetHandlerOptions_t* options);
-    [[nodiscard]] static rbusError_t eventSubHandler(rbusHandle_t handle, rbusEventSubAction_t action, const char* eventName,rbusFilter_t filter,int32_t interval,bool* autoPublish);
-    [[nodiscard]] static rbusError_t setData(rbus_data& data,rbusProperty_t property);
+    UNUSED_RESULT_CHECK static rbusError_t getHandler (rbusHandle_t handle, rbusProperty_t property, rbusGetHandlerOptions_t* options);
+    UNUSED_RESULT_CHECK static rbusError_t setHandler (rbusHandle_t handle, rbusProperty_t property, rbusSetHandlerOptions_t* options);
+    UNUSED_RESULT_CHECK static rbusError_t eventSubHandler(rbusHandle_t handle, rbusEventSubAction_t action, const char* eventName,rbusFilter_t filter,int32_t interval,bool* autoPublish);
+    UNUSED_RESULT_CHECK static rbusError_t setData(rbus_data& data,rbusProperty_t property);
     static void getData(rbus_data& data,rbusProperty_t property);
 
 protected:

--- a/src/librbusprovider/rbus_macros.h
+++ b/src/librbusprovider/rbus_macros.h
@@ -1,0 +1,31 @@
+// If not stated otherwise in this file or this component's license file the
+// following copyright and licenses apply:
+//
+// Copyright 2022 Consult Red
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#ifndef _DEVICESM_RBUS_MACROS_H
+#define _DEVICESM_RBUS_MACROS_H
+
+
+//if the c++ standard version of attributes are supported then use them, otherwise use the gcc attributes
+#if defined (__GNUC__) && __GNUC__ >= 7
+	#define UNUSED_CHECK [[maybe_unused]]
+	#define UNUSED_RESULT_CHECK [[nodiscard]]
+#else
+	#define UNUSED_CHECK  __attribute__((unused))
+	#define UNUSED_RESULT_CHECK __attribute__((warn_unused_result))
+#endif
+
+#endif

--- a/src/librbusprovider/table.cpp
+++ b/src/librbusprovider/table.cpp
@@ -34,7 +34,7 @@ template_row(row_definiton) {
 
 //alias name is the table key. it can be anything but we want it to be an index starting at 1 and incrementing up to match what rbus is doing internally
 //ignore aliasName and use index somehow
-rbusError_t rbus_table::addRow([[maybe_unused]] rbusHandle_t handle,char const* tableName,[[maybe_unused]]char const* aliasName,[[maybe_unused]] uint32_t* instNum){ 
+rbusError_t rbus_table::addRow(UNUSED_CHECK rbusHandle_t handle,char const* tableName,UNUSED_CHECK char const* aliasName,UNUSED_CHECK uint32_t* instNum){ 
     std::string name (tableName);
     
     //truncate the prefix from the name, so that we end up with the table keys as the first element
@@ -71,7 +71,7 @@ rbusError_t rbus_table::addRow([[maybe_unused]] rbusHandle_t handle,char const* 
 }
 
 //row name is the full rbus name, including the table name and the alias name
-rbusError_t rbus_table::removeRow([[maybe_unused]] rbusHandle_t handle,[[maybe_unused]] char const* rowName) {
+rbusError_t rbus_table::removeRow(UNUSED_CHECK rbusHandle_t handle,UNUSED_CHECK char const* rowName) {
     
     std::string name (rowName);
     
@@ -229,7 +229,7 @@ rbus_table * rbus_table::findTable(std::vector<std::string> const & split,bool c
     return nullptr;
 }
 
-rbusError_t rbus_table::tableGetHandler ([[maybe_unused]] rbusHandle_t handle, rbusProperty_t property, [[maybe_unused]] rbusGetHandlerOptions_t* options) { 
+rbusError_t rbus_table::tableGetHandler (UNUSED_CHECK rbusHandle_t handle, rbusProperty_t property, UNUSED_CHECK rbusGetHandlerOptions_t* options) { 
     
     rbus_data * data = find(property);
     if (data != nullptr) {
@@ -239,7 +239,7 @@ rbusError_t rbus_table::tableGetHandler ([[maybe_unused]] rbusHandle_t handle, r
     return (rbusError_t::RBUS_ERROR_BUS_ERROR);
 }
 
-rbusError_t rbus_table::tableSetHandler ([[maybe_unused]] rbusHandle_t handle, rbusProperty_t property,[[maybe_unused]] rbusSetHandlerOptions_t* options) {
+rbusError_t rbus_table::tableSetHandler (UNUSED_CHECK rbusHandle_t handle, rbusProperty_t property,UNUSED_CHECK rbusSetHandlerOptions_t* options) {
     rbus_data * data = find(property);
     if (data != nullptr) {
         return (rbus_provider::setData(*data,property));
@@ -247,7 +247,7 @@ rbusError_t rbus_table::tableSetHandler ([[maybe_unused]] rbusHandle_t handle, r
     return (rbusError_t::RBUS_ERROR_BUS_ERROR);
 }
 
-rbusError_t rbus_table::tableEventHandler([[maybe_unused]] rbusHandle_t handle, rbusEventSubAction_t action, const char* eventName,[[maybe_unused]]  rbusFilter_t filter,[[maybe_unused]]  int32_t interval,[[maybe_unused]]  bool* autoPublish) {
+rbusError_t rbus_table::tableEventHandler(UNUSED_CHECK rbusHandle_t handle, rbusEventSubAction_t action, const char* eventName,UNUSED_CHECK  rbusFilter_t filter,UNUSED_CHECK  int32_t interval,UNUSED_CHECK  bool* autoPublish) {
     std::cout << "Event for table "<< eventName <<" called: action=" << (action == RBUS_EVENT_ACTION_SUBSCRIBE ? "subscribe" : "unsubscribe") << std::endl;
     return RBUS_ERROR_SUCCESS;
 }

--- a/src/librbusprovider/table.h
+++ b/src/librbusprovider/table.h
@@ -15,6 +15,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+#include "rbus_macros.h"
 #include "provider.h"
 #include <vector>
 
@@ -49,21 +50,21 @@ private:
     
     
     //find functions return nullptr if not found
-    [[nodiscard]] static rbus_data  * find(rbusProperty_t property);
-    [[nodiscard]] static rbus_table * findTable(rbusProperty_t property,bool contains_value); //set bool to true if the string contains the value as well as the tables
-    [[nodiscard]] static rbus_table * findTable(std::string const & name,bool contains_value);
-    [[nodiscard]] static rbus_table * findTable(std::vector<std::string> const & split,bool contains_value);
+    UNUSED_RESULT_CHECK static rbus_data  * find(rbusProperty_t property);
+    UNUSED_RESULT_CHECK static rbus_table * findTable(rbusProperty_t property,bool contains_value); //set bool to true if the string contains the value as well as the tables
+    UNUSED_RESULT_CHECK static rbus_table * findTable(std::string const & name,bool contains_value);
+    UNUSED_RESULT_CHECK static rbus_table * findTable(std::vector<std::string> const & split,bool contains_value);
     void setElements(std::vector<rbusDataElement_t>& elements);
-    [[nodiscard]] static size_t getTableIndex(std::string const& in);
+    UNUSED_RESULT_CHECK static size_t getTableIndex(std::string const& in);
 
 //getters/setters need to be public otherwise they can't be used as function pointers
 public:
-    [[nodiscard]] static rbusError_t addRow(rbusHandle_t handle,char const* tableName,char const* aliasName, uint32_t* instNum);
-    [[nodiscard]] static rbusError_t removeRow(rbusHandle_t handle, char const* rowName);
-    [[nodiscard]] static rbusError_t tableGetHandler (rbusHandle_t handle, rbusProperty_t property, rbusGetHandlerOptions_t* options);
-    [[nodiscard]] static rbusError_t tableSetHandler (rbusHandle_t handle, rbusProperty_t property,rbusSetHandlerOptions_t* options);
-    [[nodiscard]] static rbusError_t tableEventHandler(rbusHandle_t handle, rbusEventSubAction_t action, const char* eventName, rbusFilter_t filter, int32_t interval, bool* autoPublish);
-    [[nodiscard]] static rbusError_t tableMethodHandler (rbusHandle_t handle, char const* methodName, rbusObject_t inParams, rbusObject_t outParams, rbusMethodAsyncHandle_t asyncHandle);
+    UNUSED_RESULT_CHECK static rbusError_t addRow(rbusHandle_t handle,char const* tableName,char const* aliasName, uint32_t* instNum);
+    UNUSED_RESULT_CHECK static rbusError_t removeRow(rbusHandle_t handle, char const* rowName);
+    UNUSED_RESULT_CHECK static rbusError_t tableGetHandler (rbusHandle_t handle, rbusProperty_t property, rbusGetHandlerOptions_t* options);
+    UNUSED_RESULT_CHECK static rbusError_t tableSetHandler (rbusHandle_t handle, rbusProperty_t property,rbusSetHandlerOptions_t* options);
+    UNUSED_RESULT_CHECK static rbusError_t tableEventHandler(rbusHandle_t handle, rbusEventSubAction_t action, const char* eventName, rbusFilter_t filter, int32_t interval, bool* autoPublish);
+    UNUSED_RESULT_CHECK static rbusError_t tableMethodHandler (rbusHandle_t handle, char const* methodName, rbusObject_t inParams, rbusObject_t outParams, rbusMethodAsyncHandle_t asyncHandle);
 
 };
 


### PR DESCRIPTION
changes to DSM that allow building on the 6.4.0 version of gcc as this is needed to support the meta-rdk layer 

Changes can be summarized as

* replace c++17 filesystem functionality
* replace c++17 structured bindings
* replaces a use of make_shared that didn't seem to work
* replace c++ attributes based on compiler version (earliest they show up is in 7, i couldn't find documentation for this but tested with compiler explorer see:https://godbolt.org/z/Wc6z7xPnK )
* change c++ standard to c++11 as c++17 features are not fully implemented and as a result behave in unintended ways
* set warning flags conditionally based on compiler version
* allows the settings of a sysroot variable and uses the GNUInstallDirs path for non-c standard headers to find rbus rather than hardcoded path of /usr/include/rbus

testing has been done on a container lifecycle, with no changes in behaviour seen. e.g. change from std::filesystem::removeall to directory walk and remove/unlink removed the entire container folder as intended.

