### PR TITLE
REFPLTB-2408 : dsm compilation error in kirkstone

### DIFF
--- a/src/utils/execute-command.hpp
+++ b/src/utils/execute-command.hpp
@@ -21,6 +21,7 @@
 
 #include <tuple>
 #include <string>
+#include <stdexcept>
 
 auto execute_command(std::string command) -> std::tuple<int, std::string>;
 


### PR DESCRIPTION
Reason for change : dsm/1.0-r0/git/src/utils/execute-command.cpp: In function 'std::tuple<int, std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > > execute_command(std::string)': error: 'runtime_error' is not a member of 'std'
ds|    30 |     if (!pipe) throw std::runtime_error("popen() failed!");
|       |                           ^~~~~~~~~~~~~
adding stdexcept include header, as it provides the runtime_error()
Test Procedure: 1.bitbake dsm
                2.do_compile issue should not be observed in dsm
Risks: Low