### PR TITLE
REFPLTB-3165 : Installing bundle using UspPa is not working in dac

### DIFF
--- a/src/datamodel/adapters/packager-adapter.cpp
+++ b/src/datamodel/adapters/packager-adapter.cpp
@@ -219,21 +219,10 @@ void PackagerAdapter::wget_callback_success(std::shared_ptr<PackageData> package
      std::cout << "Delete file=" << delete_file_command.c_str() << std::endl;
    };
 
-   std::string containerName = convertToLocalUri(localUri);
-   std::optional<std::string> stripped_filename = strip_tar_ext(containerName);
-   if (stripped_filename.has_value()) {
-	   containerName = stripped_filename.value();
-   } else {
-	   //TODO Improve Error handling
-	   std::cout << "Install Error: couldn't extract this file type" << std::endl;
-	   return;
-   }
-   std::filesystem::create_directory(dest + containerName);
-
    std::string arg1 = "-xf";
    std::string arg2 = dest + localUri;
    std::string arg3 = "-C";
-   std::string arg4 = dest + containerName;
+   std::string arg4 = dest;
 
    char * argv_list[] = {(char*)"tar",(char*)arg1.c_str(),(char*)arg2.c_str(),
                         (char*)arg3.c_str(), (char*)arg4.c_str(), NULL};


### PR DESCRIPTION
Reason for change: Addressing the issue of Device.SoftwareModules.ExecutionUnit. not created by removing containerName code , which is creating sub directories
Test procedure : Device.SoftwareModules.ExecutionUnit. should populated when installing the bundle, more information is available in comments section
Risks : None