### PR TITLE
RDKBACCL-645,REFPLTB-3408: New rbus import change is not building in dsm

### DIFF
--- a/src/librbusprovider/provider.h
+++ b/src/librbusprovider/provider.h
@@ -85,7 +85,7 @@ namespace rbus_callback_tables{
     constexpr rbusCallbackTable_t rbus_table_generic_read_write {rbus_table::tableGetHandler,rbus_table::tableSetHandler,nullptr            ,nullptr                ,nullptr                        ,nullptr};
     constexpr rbusCallbackTable_t rbus_table_generic_read_only  {rbus_table::tableGetHandler,nullptr                    ,nullptr            ,nullptr                ,nullptr                        ,nullptr};
     //constexpr rbusCallbackTable_t rbus_generic_method           {nullptr                    ,nullptr                    ,nullptr            ,nullptr                ,nullptr                        ,rbus_provider::methodHandler};
-    constexpr rbusCallbackTable_t rbus_table_generic_method     {nullptr                    ,nullptr                    ,nullptr            ,nullptr                ,nullptr                        ,rbus_table::tableMethodHandler};
+    const rbusCallbackTable_t rbus_table_generic_method     {nullptr                    ,nullptr                    ,nullptr            ,nullptr                ,nullptr                        ,reinterpret_cast<void*>(&rbus_table::tableMethodHandler)};
     constexpr rbusCallbackTable_t rbus_event                    {nullptr                    ,nullptr                    ,nullptr            ,nullptr                ,rbus_provider::eventSubHandler,nullptr};
 }
 #endif

--- a/src/rbus/dsm_rbus_provider.hpp
+++ b/src/rbus/dsm_rbus_provider.hpp
@@ -39,7 +39,7 @@ public:
 
 private:
    static bool isValidURL(std::string url);
-   rbusCallbackTable_t local_method_table = {nullptr,nullptr,nullptr,nullptr,nullptr,dsm_rbus_provider::methodHandler};
+   rbusCallbackTable_t local_method_table = {nullptr,nullptr,nullptr,nullptr,nullptr,reinterpret_cast<void*>(dsm_rbus_provider::methodHandler)};
    
    static rbusError_t methodHandler(rbusHandle_t handle, char const* methodName, rbusObject_t inParams, rbusObject_t outParams, rbusMethodAsyncHandle_t asyncHandle);
    static void stateChangeHandler(rbusHandle_t handle, rbusEvent_t const* event,rbusEventSubscription_t* subscription);


### PR DESCRIPTION
Reason for change: Fixed build issue in DSM due to rbus import type mismatch. adding this fix in 2025q2 build as well
Test Procedure: DSM component is getting compiled and functionality was working fine using usp-pa
Risks: Low